### PR TITLE
Add contentSettings to upload (fileType and disposition)

### DIFF
--- a/src/MulterAzureStorage.ts
+++ b/src/MulterAzureStorage.ts
@@ -187,7 +187,14 @@ export class MulterAzureStorage implements StorageEngine {
             // Prep stream
             let blobStream: Writable;
             if (this._metadata == null) {
-                blobStream = this._blobService.createWriteStreamToBlockBlob(containerName, blobName, (cWSTBBError, result, response) => {
+                blobStream = this._blobService.createWriteStreamToBlockBlob(containerName, blobName,
+                    {
+                        contentSettings: {
+                            contentType: file.mimetype,
+                            contentDisposition: 'inline'
+                        }
+                    }, 
+                    (cWSTBBError, result, response) => {
                     if (cWSTBBError) {
                         cb(cWSTBBError);
                     } else {

--- a/src/MulterAzureStorage.ts
+++ b/src/MulterAzureStorage.ts
@@ -200,6 +200,10 @@ export class MulterAzureStorage implements StorageEngine {
                     containerName,
                     blobName,
                     {
+                        contentSettings: {
+                            contentType: file.mimetype,
+                            contentDisposition: 'inline'
+                        },
                         metadata: metadata,
                     },
                     (cWSTBBError, result, response) => {


### PR DESCRIPTION
Adds contentSettings object to createWriteStreamToBlockBlob call. Sets the blob's contentType to the file's mime type and defaults the disposition to 'inline' allowing the file to be streamed/embedded rather than downloading.

To set the blob to download by default, send a request to the proper endpoint, setting the disposition to 'attachment'.

https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-properties
